### PR TITLE
`setup.py` - add `radii_tables` to include

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    packages=["py2sambvca"],
+    packages=["py2sambvca","py2sambvca.radii_tables"],
     include_package_data=True
 )


### PR DESCRIPTION
Urgent fix! Current version on PyPI cannot import radii tables because they were not included in the PyPI package.